### PR TITLE
Fix k3s networking issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,10 @@ kubectl apply -f hosts/nandstorm/k8s/apps
 
 This installs MetalLB, ExternalDNS, the NVIDIA device plugin and exposes
 Jellyfin, Transmission and friends via Traefik with TLS.
+
+### Networking requirements
+
+The server must load the `br_netfilter` and `overlay` kernel modules and
+enable bridge firewalling so the bundled flannel CNI works correctly.  This is
+handled in `hosts/nandstorm/default.nix` but is worth noting when porting the
+configuration to other machines.

--- a/hosts/nandstorm/default.nix
+++ b/hosts/nandstorm/default.nix
@@ -45,6 +45,13 @@
     };
   };
 
+  # Networking prerequisites for Kubernetes
+  boot.kernelModules = [ "br_netfilter" "overlay" ];
+  boot.kernel.sysctl = {
+    "net.bridge.bridge-nf-call-iptables" = 1;
+    "net.bridge.bridge-nf-call-ip6tables" = 1;
+  };
+
   networking.hostId = "deadb33f";
   networking.hostName = "nandstorm"; # Define your hostname.
   networking.nameservers = [

--- a/hosts/nandstorm/k8s/infrastructure/metallb.yaml
+++ b/hosts/nandstorm/k8s/infrastructure/metallb.yaml
@@ -8,6 +8,9 @@ spec:
   chart: metallb
   version: v0.14.3
   targetNamespace: metallb-system
+  valuesContent: |
+    crds:
+      enabled: true
 ---
 apiVersion: metallb.io/v1beta1
 kind: IPAddressPool


### PR DESCRIPTION
## Summary
- ensure overlay and br_netfilter modules are loaded for k3s
- install Metallb CRDs automatically via HelmChart
- mention networking requirements in README

## Testing
- `git commit -m "Enable bridge networking and install Metallb CRDs"`
- *Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.*

------
https://chatgpt.com/codex/tasks/task_e_685758b74f7c832bbd05657df62da095